### PR TITLE
SQS Event Source

### DIFF
--- a/config/event_sources_development.json
+++ b/config/event_sources_development.json
@@ -1,9 +1,8 @@
 {
   "EventSourceMappings": [
     {
-      "EventSourceArn": "arn:aws:kinesis:us-east-1:224280085904:stream/sfr-oclc-lookup-development",
+      "EventSourceArn": "arn:aws:sqs:us-east-1:224280085904:sfr-oclc-lookup-development",
       "BatchSize": 10,
-      "StartingPosition": "LATEST",
       "Enabled": true
     }
   ]

--- a/helpers/clientHelpers.py
+++ b/helpers/clientHelpers.py
@@ -63,12 +63,12 @@ def createEventMapping(runType):
             'EventSourceArn': mapping['EventSourceArn'],
             'FunctionName': configDict['function_name'],
             'Enabled': mapping['Enabled'],
-            'BatchSize': mapping['BatchSize'],
-            'StartingPosition': mapping['StartingPosition']
+            'BatchSize': mapping['BatchSize']
         }
-
-        if mapping['StartingPosition'] == 'AT_TIMESTAMP':
-            createKwargs['StartingPositionTimestamp'] = mapping['StartingPositionTimestamp']  # noqa: E501
+        if 'StartingPosition' in mapping:
+            createKwargs['StartingPosition'] = mapping['StartingPosition']
+            if mapping['StartingPosition'] == 'AT_TIMESTAMP':
+                createKwargs['StartingPositionTimestamp'] = mapping['StartingPositionTimestamp']  # noqa: E501
 
         try:
             lambdaClient.create_event_source_mapping(**createKwargs)

--- a/lib/parsers/parseOCLC.py
+++ b/lib/parsers/parseOCLC.py
@@ -198,6 +198,7 @@ def _matchURIIdentifier(instance, uri, id_regex):
                 'identifier': idGroup.group(1),
                 'weight': 0.8
             })
+            return True
 
 
 def _matchRegexEbook(instance, uri, ebook_regex, uriIdentifier):
@@ -209,12 +210,19 @@ def _matchRegexEbook(instance, uri, ebook_regex, uriIdentifier):
                 'link': Link(url=uri, mediaType='text/html'),
                 'identifier': Identifier(identifier=uriIdentifier)
             })
+            return True
 
 
 def _addEbook(instance, holding, subfield, uri, uriIdentifier):
     try:
         fieldText = holding.subfield(subfield)[0].value
-        uriSource = re.search(r'([a-z0-9]+)\.[a-z]{2,3}(?:$|\/|\.[a-z]{2}(?:$|\/))', uri).group(1)
+        try:
+            uriSource = re.search(
+                r'([a-z0-9]+)\.[a-z]{2,4}(?:$|\/|:[0-9]{2,5}|\.[a-z]{2}(?:$|\/))',
+                    uri
+            ).group(1)
+        except AttributeError:
+            uriSource = uri
         if 'epub' in fieldText.lower() or 'ebook' in fieldText.lower():
             logger.info('Adding format for instance record for {}'.format(uri))
             instance.addFormat(**{

--- a/lib/recordFetch.py
+++ b/lib/recordFetch.py
@@ -14,9 +14,8 @@ def fetchData(record):
     the corresponding record."""
 
     try:
-        dataBlock = record['data']
-        idenType = dataBlock['type']
-        identifier = dataBlock['identifier']
+        idenType = record['type']
+        identifier = record['identifier']
     except KeyError as e:
         logger.error('Missing attribute in data block!')
         logger.debug(e)

--- a/service.py
+++ b/service.py
@@ -45,15 +45,13 @@ def parseRecord(encodedRec):
     decoded from the input base64 encoded string and if so, hands this to the
     enhancer method"""
     try:
-        record = json.loads(base64.b64decode(encodedRec['kinesis']['data']))
+        record = json.loads(encodedRec['body'])
         return fetchData(record)
     except json.decoder.JSONDecodeError as jsonErr:
         logger.error('Invalid JSON block recieved')
         logger.error(jsonErr)
-    except UnicodeDecodeError as b64Err:
-        logger.error('Invalid data found in base64 encoded block')
-        logger.debug(b64Err)
-    except (OCLCError, DataError):
-        logger.warning('Error raised during processing, no data fetched from OCLC')
-
-    return False
+        raise DataError('Malformed JSON block recieved from SQS')
+    except KeyError as err:
+        logger.error('Missing body attribute in SQS message')
+        logger.debug(err)
+        raise DataError('Body object missing from SQS message')

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -13,10 +13,8 @@ class TestFetcher(unittest.TestCase):
     @patch('lib.recordFetch.KinesisOutput.putRecord')
     def test_basic_fetcher(self, mock_parse, mock_lookup, mock_put):
         testRec = {
-            'data': {
-                'type': 'oclc',
-                'identifier': '000000000'
-            }
+            'type': 'oclc',
+            'identifier': '000000000'
         }
 
         res = fetchData(testRec)
@@ -49,10 +47,8 @@ class TestFetcher(unittest.TestCase):
 
     def test_non_oclc_identifier(self):
         testRec = {
-            'data': {
-                'type': 'isbn',
-                'identifier': '0000000000'
-            }
+            'type': 'isbn',
+            'identifier': '0000000000'
         }
 
         try:


### PR DESCRIPTION
Update the OCLC Catalog Lookup function to read from SQS queue as an event source, as opposed to a Kinesis stream of identical records. 

This has several advantages, including increased throughput/concurrency, as well as the cost savings associated with the queue over the event stream. This is part of an overall effort to decrease the average processing time of records in the SFR pipeline and does effectively remove a bottleneck at this point in the process.