### PR TITLE
Improved url parsing

### DIFF
--- a/config/event_sources_development.json
+++ b/config/event_sources_development.json
@@ -1,9 +1,8 @@
 {
   "EventSourceMappings": [
     {
-      "EventSourceArn": "arn:aws:kinesis:us-east-1:224280085904:stream/sfr-oclc-lookup-development",
+      "EventSourceArn": "arn:aws:sqs:us-east-1:224280085904:sfr-oclc-lookup-development",
       "BatchSize": 10,
-      "StartingPosition": "LATEST",
       "Enabled": true
     }
   ]

--- a/helpers/clientHelpers.py
+++ b/helpers/clientHelpers.py
@@ -63,12 +63,12 @@ def createEventMapping(runType):
             'EventSourceArn': mapping['EventSourceArn'],
             'FunctionName': configDict['function_name'],
             'Enabled': mapping['Enabled'],
-            'BatchSize': mapping['BatchSize'],
-            'StartingPosition': mapping['StartingPosition']
+            'BatchSize': mapping['BatchSize']
         }
-
-        if mapping['StartingPosition'] == 'AT_TIMESTAMP':
-            createKwargs['StartingPositionTimestamp'] = mapping['StartingPositionTimestamp']  # noqa: E501
+        if 'StartingPosition' in mapping:
+            createKwargs['StartingPosition'] = mapping['StartingPosition']
+            if mapping['StartingPosition'] == 'AT_TIMESTAMP':
+                createKwargs['StartingPositionTimestamp'] = mapping['StartingPositionTimestamp']  # noqa: E501
 
         try:
             lambdaClient.create_event_source_mapping(**createKwargs)

--- a/lib/parsers/parseOCLC.py
+++ b/lib/parsers/parseOCLC.py
@@ -198,6 +198,7 @@ def _matchURIIdentifier(instance, uri, id_regex):
                 'identifier': idGroup.group(1),
                 'weight': 0.8
             })
+            return True
 
 
 def _matchRegexEbook(instance, uri, ebook_regex, uriIdentifier):
@@ -209,12 +210,19 @@ def _matchRegexEbook(instance, uri, ebook_regex, uriIdentifier):
                 'link': Link(url=uri, mediaType='text/html'),
                 'identifier': Identifier(identifier=uriIdentifier)
             })
+            return True
 
 
 def _addEbook(instance, holding, subfield, uri, uriIdentifier):
     try:
         fieldText = holding.subfield(subfield)[0].value
-        uriSource = re.search(r'([a-z0-9]+)\.[a-z]{2,3}(?:$|\/|\.[a-z]{2}(?:$|\/))', uri).group(1)
+        try:
+            uriSource = re.search(
+                r'([a-z0-9]+)\.[a-z]{2,4}(?:$|\/|:[0-9]{2,5}|\.[a-z]{2}(?:$|\/))',
+                    uri
+            ).group(1)
+        except AttributeError:
+            uriSource = uri
         if 'epub' in fieldText.lower() or 'ebook' in fieldText.lower():
             logger.info('Adding format for instance record for {}'.format(uri))
             instance.addFormat(**{

--- a/lib/parsers/parseOCLC.py
+++ b/lib/parsers/parseOCLC.py
@@ -141,6 +141,17 @@ def readFromMARC(marcRecord):
 
 
 def extractHoldingsLinks(holdings, instance):
+
+    ebook_regex = {
+        'gutenberg': r'gutenberg.org\/ebooks\/[0-9]+\.epub\.(?:no|)images$',
+        'internetarchive': r'archive.org\/details\/[a-z0-9]+$'
+    }
+
+    id_regex = {
+        'oclc': r'oclc\/([0-9]+)',
+        'gutenberg': r'gutenberg.org\/ebooks\/([0-9]+)$'
+    }
+
     for holding in holdings:
         if holding.ind1 != '4':
             continue
@@ -149,46 +160,74 @@ def extractHoldingsLinks(holdings, instance):
         except IndexError:
             logger.info('Could not load URI for identifier, skipping')
             continue
+        uriIdentifier = _loadURIIdentifier(uri)
 
+        if _matchRegexEbook(instance, uri, ebook_regex, uriIdentifier):
+            continue
 
-        uriGroup = re.search(r'\/((?:(?!\/).)+)$', uri)
-        if uriGroup is not None:
-            uriIdentifier = uriGroup.group(1)
-        else:
-            uriIdentifier = uri
+        if _addEbook(instance, holding, 'q', uri, uriIdentifier):
+            continue
+        if _addEbook(instance, holding, 'z', uri, uriIdentifier):
+            continue
 
-        try:
-            holdingFormat = holding.subfield('q')[0].value
-            if 'epub' in holdingFormat.lower():
-                logger.info('Adding format for instance record for {}'.format(uri))
-                instance.addFormat(**{
-                    'content_type': holdingFormat,
-                    'link': Link(url=uri, mediaType='text/html'),
-                    'identifier': Identifier(identifier=uriIdentifier)
-                })
-                continue
-        except IndexError:
-            pass
-
-        try:
-            note = holding.subfield('z')[0].value
-            if 'epub' in note.lower() or 'ebook' in note.lower():
-                logger.info('Adding format for instance record for {}'.format(uri))
-                instance.addFormat(**{
-                    'content_type': 'ebook',
-                    'link': Link(url=uri, mediaType='text/html'),
-                    'identifier': Identifier(identifier=uriIdentifier)
-                })
-                continue
-        except IndexError:
-            pass
-
+        if _matchURIIdentifier(instance, uri, id_regex):
+            continue
         logger.info('Adding link relationship for {}'.format(uri))
         instance.addLink(**{
             'url': uri,
             'media_type': 'text/html',
             'rel_type': 'associated'
         })
+
+
+def _loadURIIdentifier(uri):
+    uriGroup = re.search(r'\/((?:(?!\/).)+)$', uri)
+    if uriGroup is not None:
+        uriIdentifier = uriGroup.group(1)
+    else:
+        uriIdentifier = uri
+    return uriIdentifier
+
+
+def _matchURIIdentifier(instance, uri, id_regex):
+    for idType, regex in id_regex.items():
+        idGroup = re.search(regex, uri)
+        if idGroup is not None:
+            instance.addIdentifier(**{
+                'type': idType,
+                'identifier': idGroup.group(1),
+                'weight': 0.8
+            })
+
+
+def _matchRegexEbook(instance, uri, ebook_regex, uriIdentifier):
+    for source, regex in ebook_regex.items():
+        if re.search(regex, uri):
+            instance.addFormat(**{
+                'source': source,
+                'content_type': 'ebook',
+                'link': Link(url=uri, mediaType='text/html'),
+                'identifier': Identifier(identifier=uriIdentifier)
+            })
+
+
+def _addEbook(instance, holding, subfield, uri, uriIdentifier):
+    try:
+        fieldText = holding.subfield(subfield)[0].value
+        uriSource = re.search(r'([a-z0-9]+)\.[a-z]{2,3}(?:$|\/|\.[a-z]{2}(?:$|\/))', uri).group(1)
+        if 'epub' in fieldText.lower() or 'ebook' in fieldText.lower():
+            logger.info('Adding format for instance record for {}'.format(uri))
+            instance.addFormat(**{
+                'source': uriSource,
+                'content_type': 'ebook',
+                'link': Link(url=uri, mediaType='text/html'),
+                'identifier': Identifier(identifier=uriIdentifier)
+            })
+            return True
+    except IndexError:
+        pass
+    
+    return False
 
 
 def extractSubjects(data, instance, field):
@@ -226,7 +265,7 @@ def extractSubjects(data, instance, field):
             try:
                 subject['authority'] = SUBJECT_INDICATORS[subj.ind2]
             except KeyError as err:
-                logger.error('Unknown subject authority found for {}', instance)
+                logger.error('Unknown subject authority found for {}'.format(instance))
                 logger.debug(err)
         else:
             try:

--- a/lib/recordFetch.py
+++ b/lib/recordFetch.py
@@ -14,9 +14,8 @@ def fetchData(record):
     the corresponding record."""
 
     try:
-        dataBlock = record['data']
-        idenType = dataBlock['type']
-        identifier = dataBlock['identifier']
+        idenType = record['type']
+        identifier = record['identifier']
     except KeyError as e:
         logger.error('Missing attribute in data block!')
         logger.debug(e)

--- a/service.py
+++ b/service.py
@@ -45,15 +45,13 @@ def parseRecord(encodedRec):
     decoded from the input base64 encoded string and if so, hands this to the
     enhancer method"""
     try:
-        record = json.loads(base64.b64decode(encodedRec['kinesis']['data']))
+        record = json.loads(encodedRec['body'])
         return fetchData(record)
     except json.decoder.JSONDecodeError as jsonErr:
         logger.error('Invalid JSON block recieved')
         logger.error(jsonErr)
-    except UnicodeDecodeError as b64Err:
-        logger.error('Invalid data found in base64 encoded block')
-        logger.debug(b64Err)
-    except (OCLCError, DataError):
-        logger.warning('Error raised during processing, no data fetched from OCLC')
-
-    return False
+        raise DataError('Malformed JSON block recieved from SQS')
+    except KeyError as err:
+        logger.error('Missing body attribute in SQS message')
+        logger.debug(err)
+        raise DataError('Body object missing from SQS message')

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -13,10 +13,8 @@ class TestFetcher(unittest.TestCase):
     @patch('lib.recordFetch.KinesisOutput.putRecord')
     def test_basic_fetcher(self, mock_parse, mock_lookup, mock_put):
         testRec = {
-            'data': {
-                'type': 'oclc',
-                'identifier': '000000000'
-            }
+            'type': 'oclc',
+            'identifier': '000000000'
         }
 
         res = fetchData(testRec)
@@ -49,10 +47,8 @@ class TestFetcher(unittest.TestCase):
 
     def test_non_oclc_identifier(self):
         testRec = {
-            'data': {
-                'type': 'isbn',
-                'identifier': '0000000000'
-            }
+            'type': 'isbn',
+            'identifier': '0000000000'
         }
 
         try:

--- a/tests/test_parseOCLC.py
+++ b/tests/test_parseOCLC.py
@@ -1,24 +1,144 @@
 from lxml import etree
 import unittest
-from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock, Mock, patch
 
-from lib.parsers.parseOCLC import readFromMARC
+from lib.parsers.parseOCLC import (
+    extractHoldingsLinks,
+    _addEbook,
+    _loadURIIdentifier,
+    _matchURIIdentifier,
+    _matchRegexEbook
+)
 from lib.dataModel import WorkRecord
 
 class TestOCLCParse(unittest.TestCase):
 
-    def test_classify_read(self):
-        #mockXML = Mock()
-        #work = etree.Element('work',
-        #    title='Test Work',
-        #    editions='1',
-        #    holdings='1',
-        #    eholdings='1',
-        #    owi='1111111',
-        #)
-        #work.text = '0000000000'
-        #mockXML.find = MagicMock(return_value=work)
-        #mockXML.findall = MagicMock(return_value=[])
-        #res = readFromClassify(mockXML)
-        #self.assertIsInstance(res, WorkRecord)
-        pass
+    @patch('lib.parsers.parseOCLC._loadURIIdentifier')
+    @patch('lib.parsers.parseOCLC._matchRegexEbook', return_value=False)
+    @patch('lib.parsers.parseOCLC._addEbook', return_value=False)
+    @patch('lib.parsers.parseOCLC._matchURIIdentifier', return_value=False)
+    def test_holdings_extraction(self, mock_load, mock_match, mock_add, mock_matchURI):
+        mock_add = MagicMock()
+        mock_instance = MagicMock()
+        mock_instance.addLink = mock_add
+        mock_holding = MagicMock()
+        mock_holding.ind1 = '4'
+        extractHoldingsLinks([mock_holding], mock_instance)
+        mock_add.assert_called_once()
+    
+
+    def test_holdings_skip_field(self):
+        mock_holding = MagicMock()
+        mock_holding.ind1 = '0'
+        
+        mock_add = MagicMock()
+        mock_instance = MagicMock()
+        mock_instance.addLink = mock_add
+        extractHoldingsLinks([mock_holding], mock_instance)
+        mock_add.assert_not_called()
+    
+    def test_holdings_bad_uri(self):
+        mock_holding = MagicMock()
+        mock_holding.ind1 = '4'
+        mock_holding.subfield.side_effect = IndexError
+        mock_add = MagicMock()
+        mock_instance = MagicMock()
+        mock_instance.addLink = mock_add
+        extractHoldingsLinks([mock_holding], mock_instance)
+        mock_add.assert_not_called()
+
+    def test_add_ebook(self):
+        mock_value = MagicMock()
+        mock_value.value = 'An epub!'
+        mock_holding = MagicMock()
+        mock_holding.subfield.return_value = [mock_value]
+        mock_instance = MagicMock()
+        res = _addEbook(
+            mock_instance,
+            mock_holding,
+            't',
+            'http://test.com/1234.epub',
+            '1234.epub'
+        )
+        self.assertTrue(res)
+    
+    def test_add_ebook_skip(self):
+        mock_value = MagicMock()
+        mock_value.value = 'Not a Copy'
+        mock_holding = MagicMock()
+        mock_holding.subfield.return_value = [mock_value]
+        mock_instance = MagicMock()
+        res = _addEbook(
+            mock_instance,
+            mock_holding,
+            't',
+            'http://another.test.co.uk/1234',
+            '1234'
+        )
+        self.assertEqual(res, False)
+    
+    def test_load_identifier(self):
+        uriID = _loadURIIdentifier('http://test.org/a1b2c3c4')
+        self.assertEqual(uriID, 'a1b2c3c4')
+    
+    def test_load_identifier_uri(self):
+        uriID = _loadURIIdentifier('http://test.org/a1b2c3c4/')
+        self.assertEqual(uriID, 'http://test.org/a1b2c3c4/')
+    
+    def test_match_identifier(self):
+        mock_add = MagicMock()
+        mock_instance = MagicMock()
+        mock_instance.addIdentifier = mock_add
+        test_regex = {
+            'test': 'test/([0-9]+)$'
+        }
+        _matchURIIdentifier(
+            mock_instance,
+            'http://test.org/test/12345',
+            test_regex
+        )
+        mock_add.assert_called_once()
+    
+    def test_match_identifier_skip(self):
+        mock_add = MagicMock()
+        mock_instance = MagicMock()
+        mock_instance.addIdentifier = mock_add
+        test_regex = {
+            'test': 'test/([0-9]+)$'
+        }
+        _matchURIIdentifier(
+            mock_instance,
+            'http://test.org/other/12345',
+            test_regex
+        )
+        mock_add.assert_not_called()
+    
+    def test_match_ebook(self):
+        mock_add = MagicMock()
+        mock_instance = MagicMock()
+        mock_instance.addFormat = mock_add
+        test_regex = {
+            'test': 'test/([0-9]+).epub$'
+        }
+        _matchRegexEbook(
+            mock_instance,
+            'http://test.org/test/12345.epub',
+            test_regex,
+            '12345'
+        )
+        mock_add.assert_called_once()
+    
+    def test_match_ebook_skip(self):
+        mock_add = MagicMock()
+        mock_instance = MagicMock()
+        mock_instance.addFormat = mock_add
+        test_regex = {
+            'test': 'test/([0-9]+).epub$'
+        }
+        _matchRegexEbook(
+            mock_instance,
+            'http://test.org/other/12345',
+            test_regex,
+            '12345'
+        )
+        mock_add.assert_not_called()


### PR DESCRIPTION
Implement improved parsing of the 856 field in MARC records, which contains holdings data. Specifically, this improves how URLs that are in the `u` subfield of `856` are understood.

This is a two-fold improvement. First, a regex is implemented that better identifies accessible ebook records from InternetArchive and Project Gutenberg that can be made directly accessible to SFR users.

Second, another regex is implemented that extracts useful identifiers from records that include things such as OCLC and Gutenberg identifiers. Transforming these from URLs to identifiers reduces duplicate links in the SFR database and allows for more accurate matching to be made, mainly between Instances.