### PR TITLE
Link flag update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
 - 3.7
 install:
 - pip install --upgrade pip
+- pip install -r dev-requirements.txt
 - pip install -r requirements.txt
 script: make test
 # after_success:

--- a/README.md
+++ b/README.md
@@ -1,22 +1,31 @@
 # OCLC Lookup Service
+
+[![Build Status](https://travis-ci.com/NYPL/sfr-oclc-catalog-lookup.svg?branch=development)](https://travis-ci.com/NYPL/sfr-oclc-catalog-lookup)
+![GitHub tag (latest SemVer)](https://img.shields.io/github/tag/nypl/sfr-oclc-catalog-lookup.svg)
+
 A lambda function that takes OCLC identifiers and returns a parsed version of the MARCXML record that is returned through the [OCLC Catalog lookup](https://www.oclc.org/developer/develop/web-services/worldcat-search-api/bibliographic-resource.en.html) service.
 
 The returned data corresponds to the Instance level records in the SFR data model.
 
 ## Version
-v0.0.1
+v0.1.0
 
 ## Note
 This code is based on the [Python Lambda Boilerplate](https://github.com/NYPL/python-lambda-boilerplate), and as a result can be run through the `make` commands detailed there such as `make test` and `make local-run`
 
 ## Dependencies
+
 - boto3
-- coverage
-- flake8
 - marcalyx
 - python-lambda
 - pyyaml
 - requests
+
+## Dev Dependencies
+
+- coverage
+- flake8
+
 
 ## Environment Variables
 - LOG_LEVEL

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,2 @@
+coverage
+flake8

--- a/lib/dataModel.py
+++ b/lib/dataModel.py
@@ -193,12 +193,12 @@ class Identifier(DataObject):
 
 
 class Link(DataObject):
-    def __init__(self, url=None, mediaType=None, relType=None):
+    def __init__(self, url=None, mediaType=None, flags=None):
         super()
         self.url = url
         self.media_type = mediaType
         self.content = None
-        self.rel_type = None
+        self.flags = flags
         self.thumbnail = None
 
 

--- a/lib/parsers/parseOCLC.py
+++ b/lib/parsers/parseOCLC.py
@@ -176,7 +176,12 @@ def extractHoldingsLinks(holdings, instance):
         instance.addLink(**{
             'url': uri,
             'media_type': 'text/html',
-            'rel_type': 'associated'
+            'flags': {
+                'local': False,
+                'download': False,
+                'images': False,
+                'ebook': False
+            }
         })
 
 
@@ -204,10 +209,16 @@ def _matchURIIdentifier(instance, uri, id_regex):
 def _matchRegexEbook(instance, uri, ebook_regex, uriIdentifier):
     for source, regex in ebook_regex.items():
         if re.search(regex, uri):
+            bookFlags = {
+                'local': False,
+                'download': False,
+                'images': False,
+                'ebook': True
+            }
             instance.addFormat(**{
                 'source': source,
                 'content_type': 'ebook',
-                'links': [Link(url=uri, mediaType='text/html', relType='external_view')],
+                'links': [Link(url=uri, mediaType='text/html', flags=bookFlags)],
                 'identifiers': [Identifier(identifier=uriIdentifier)]
             })
             return True
@@ -225,10 +236,16 @@ def _addEbook(instance, holding, subfield, uri, uriIdentifier):
             uriSource = uri
         if 'epub' in fieldText.lower() or 'ebook' in fieldText.lower():
             logger.info('Adding format for instance record for {}'.format(uri))
+            bookFlags = {
+                'local': False,
+                'download': False,
+                'images': False,
+                'ebook': True
+            }
             instance.addFormat(**{
                 'source': uriSource,
                 'content_type': 'ebook',
-                'links': [Link(url=uri, mediaType='text/html', relType='external_view')],
+                'links': [Link(url=uri, mediaType='text/html', flags=bookFlags)],
                 'identifiers': [Identifier(identifier=uriIdentifier)]
             })
             return True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
 boto3
-coverage
-flake8
 lxml
 marcalyx
 python-lambda

--- a/tests/test_dataModel.py
+++ b/tests/test_dataModel.py
@@ -78,8 +78,9 @@ class DataModel(unittest.TestCase):
 
     def test_format_setLink(self):
         testFormat = Format('ebook', 'test', 'now')
-        testFormat.setLink(**{'url': 'https://hello.hello', 'mediaType': 'text/html', 'relType': 'reference'})
-        self.assertEqual(testFormat.links[0].relType, 'reference')
+        testFlags = {'local': False, 'download': False, 'ebook': True}
+        testFormat.setLink(**{'url': 'https://hello.hello', 'mediaType': 'text/html', 'flags': testFlags})
+        self.assertTrue(testFormat.links[0].flags['ebook'])
 
     def test_agent_non_matching(self):
         new = [Agent('Test, Tester', 'tester')]


### PR DESCRIPTION
This replaces the `rel_type` attribute of `Links` with the `flags` attribute, which is stored in the database as a JSON object. This attribute can hold the following boolean flags (at the moment):

- local
- download
- ebook
- images

This set of flags, combined with the `media_type` attribute allows for all current links to be fully described in a way that is much more easily parsed for meaning. Storing these flags as a JSON object also means that further flags can be added in the future without necessitating a database migration, lowering the amount of maintenance and making updates a much smoother process.