### PR TITLE
Handle errored requests to OCLC Lookup

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,7 +12,7 @@ aws_access_key_id:
 aws_secret_access_key:
 
 # dist_directory: dist
-timeout: 15
+timeout: 60
 memory_size: 128
 
 

--- a/lib/readers/oclcLookup.py
+++ b/lib/readers/oclcLookup.py
@@ -1,4 +1,5 @@
 import requests
+from requests.exceptions import Timeout, ConnectionError
 import os
 from lxml import etree
 import marcalyx
@@ -52,7 +53,12 @@ def parseMARC(marcData):
 
 def catalogLookup(queryURL):
     """Execute a request against the OCLC Catalog service"""
-    classifyResp = requests.get(queryURL)
+    try:
+        classifyResp = requests.get(queryURL, timeout=2)
+    except (Timeout, ConnectionError):
+        logger.warning('Failed to query URL {}'.format(queryURL))
+        classifyResp = requests.get(queryURL, timeout=5)
+
     if classifyResp.status_code != 200:
         logger.error('OCLC Catalog Request failed')
         logger.debug(classifyResp.body)


### PR DESCRIPTION
At present the OCLC lookup service can respond with a range of unclear/opaque errors, including 104 Connection Reset and others. This sets a short timeout for the initial request (2 seconds, when successful processing usually takes at most 750ms). If this times out or recieves a `ConnectionError` this will retry once at a longer timeout before failing. This should a) improve the success rate for OCLC lookup queries and b) lower the error rate for the lambda function