### PR TITLE
SFR-714 add blacklist functionality

### DIFF
--- a/lib/parsers/parseOCLC.py
+++ b/lib/parsers/parseOCLC.py
@@ -159,7 +159,7 @@ def extractHoldingsLinks(holdings, instance):
     ebook_regex = {
         'gutenberg': r'gutenberg.org\/ebooks\/[0-9]+\.epub\.(?:no|)images$',
         'internetarchive': r'archive.org\/details\/[a-z0-9]+$',
-        'hathitrust': r'catalog.hathitrust.org\/api\/volumes\/[a-z]{3,6}\/[a-zA-Z0-9]+\.html'  # noqa: E901
+        'hathitrust': r'catalog.hathitrust.org\/api\/volumes\/[a-z]{3,6}\/[a-zA-Z0-9]+\.html'  # noqa: E501
     }
 
     id_regex = {
@@ -197,6 +197,12 @@ def extractHoldingsLinks(holdings, instance):
 
 
 def _loadURIIdentifier(uri):
+    # Regex to extract identifier from an URI
+    # \/((?:(?!\/)[^.])+ matches the path of the URI, excluding anything before
+    # the final slash (e.g. will match "1234" from http://test.com/1234)
+    # (?=$|\.[a-z]{3,4}$)) is a positive lookahead that excludes the file
+    # format from the identifier (so the above will still return "1234" if the
+    # URI ends in "1234.epub")
     uriGroup = re.search(r'\/((?:(?!\/)[^.])+(?=$|\.[a-z]{3,4}$))', uri)
     if uriGroup is not None:
         uriIdentifier = uriGroup.group(1)

--- a/lib/parsers/parseOCLC.py
+++ b/lib/parsers/parseOCLC.py
@@ -33,9 +33,7 @@ def readFromMARC(marcRecord):
         'weight': 1
     })
 
-    generalInfo = marcRecord['008'][0].value
-    instance.language = generalInfo[35:38]
-    print(instance.language)
+    parsedDate = parse008ControlField(marcRecord['008'][0].value, instance)
 
     # Code Fields (Identifiers)
     logger.debug('Parsing 0X0-0XX Fields')
@@ -90,6 +88,8 @@ def readFromMARC(marcRecord):
     for field in editionData:
         extractSubfieldValue(marcRecord, instance, field)
 
+    parsePubDate(instance.dates, parsedDate)
+
     # Physical Details
     # TODO Load fields into items/measurements?
     logger.debug('Parsing Extent (300) Field')
@@ -138,6 +138,20 @@ def readFromMARC(marcRecord):
     # 80X-83X
 
     return instance
+
+
+def parse008ControlField(fieldData, instance):
+    instance.language = fieldData[35:38]
+    logger.debug('Found language code {} in 008 field'.format(
+        instance.language)
+    )
+
+    return fieldData[7:11]
+
+
+def parsePubDate(dates, parsedPubDate):
+    pubDate = list(filter(lambda x: x['date_type'] == 'pub_date', dates))[0]
+    pubDate.date_range = parsedPubDate
 
 
 def extractHoldingsLinks(holdings, instance):

--- a/tests/test_parseOCLC.py
+++ b/tests/test_parseOCLC.py
@@ -4,7 +4,6 @@ from unittest.mock import MagicMock, Mock, patch
 
 from lib.parsers.parseOCLC import (
     extractHoldingsLinks,
-    _addEbook,
     _loadURIIdentifier,
     _matchURIIdentifier,
     _matchRegexEbook
@@ -15,16 +14,12 @@ class TestOCLCParse(unittest.TestCase):
 
     @patch('lib.parsers.parseOCLC._loadURIIdentifier')
     @patch('lib.parsers.parseOCLC._matchRegexEbook', return_value=False)
-    @patch('lib.parsers.parseOCLC._addEbook', return_value=False)
     @patch('lib.parsers.parseOCLC._matchURIIdentifier', return_value=False)
-    def test_holdings_extraction(self, mock_load, mock_match, mock_add, mock_matchURI):
-        mock_add = MagicMock()
+    def test_holdings_extraction(self, mock_load, mock_match, mock_matchURI):
         mock_instance = MagicMock()
-        mock_instance.addLink = mock_add
         mock_holding = MagicMock()
         mock_holding.ind1 = '4'
         extractHoldingsLinks([mock_holding], mock_instance)
-        mock_add.assert_called_once()
     
 
     def test_holdings_skip_field(self):
@@ -47,36 +42,6 @@ class TestOCLCParse(unittest.TestCase):
         extractHoldingsLinks([mock_holding], mock_instance)
         mock_add.assert_not_called()
 
-    def test_add_ebook(self):
-        mock_value = MagicMock()
-        mock_value.value = 'An epub!'
-        mock_holding = MagicMock()
-        mock_holding.subfield.return_value = [mock_value]
-        mock_instance = MagicMock()
-        res = _addEbook(
-            mock_instance,
-            mock_holding,
-            't',
-            'http://test.com/1234.epub',
-            '1234.epub'
-        )
-        self.assertTrue(res)
-    
-    def test_add_ebook_skip(self):
-        mock_value = MagicMock()
-        mock_value.value = 'Not a Copy'
-        mock_holding = MagicMock()
-        mock_holding.subfield.return_value = [mock_value]
-        mock_instance = MagicMock()
-        res = _addEbook(
-            mock_instance,
-            mock_holding,
-            't',
-            'http://another.test.co.uk/1234',
-            '1234'
-        )
-        self.assertEqual(res, False)
-    
     def test_load_identifier(self):
         uriID = _loadURIIdentifier('http://test.org/a1b2c3c4')
         self.assertEqual(uriID, 'a1b2c3c4')


### PR DESCRIPTION
This updates the manner in which we are fetching ebook links through the OCLC lookup service, limiting it to a defined list of providers, chosen by the team.

This ensures that the project is not serving local links from libraries that are only available to their patrons, among other cases.

It does so by applying a regex for each approved provider and ensuring that the URI matches what we know to be an accessible link.

There is also a minor change to the fetching of publication dates and languages as that code existed in an un-committed state, and should be included here.