### PR TITLE
SFR-703 Query corporate names

### DIFF
--- a/lib/parsers/parseOCLC.py
+++ b/lib/parsers/parseOCLC.py
@@ -359,10 +359,14 @@ def buildAgent(name, role):
 
     newAgent = Agent(name=name, role=role)
 
-    viafResp = requests.get('{}{}'.format(
+    queryStr = '{}{}'.format(
         'https://dev-platform.nypl.org/api/v0.1/research-now/viaf-lookup?queryName=',
         quote_plus(name)
-    ))
+    )
+    if role in ['publisher', 'manufacturer']:
+        queryStr = '{}&{}'.format(queryStr, 'queryType=publisher')
+
+    viafResp = requests.get(queryStr)
     responseJSON = viafResp.json()
     logger.debug(responseJSON)
     if 'viaf' in responseJSON:


### PR DESCRIPTION
This sets the lookups for the VIAF identifiers for `publishers` and `manufacturers` for instances to be corporate name records. Rarely, if ever are these personal nomes, and this will greately increase the accuracy of the lookup process.