### PR TITLE
SFR-802 Update Item creator to use Hathi bib id

### DIFF
--- a/lib/parsers/parse856Holding.py
+++ b/lib/parsers/parse856Holding.py
@@ -155,7 +155,7 @@ class HoldingParser:
                     local=False, download=True, images=True, ebook=False
                 )
             ],
-            'identifiers': [Identifier(identifier=self.identifier)]
+            'identifiers': [Identifier(identifier=hathiID)]
         })
 
     @staticmethod


### PR DESCRIPTION
This updates the hathitrust item creator method to use the locally parsed hathitrust bib identifier rather than the more general catalog identifier which does not provide as much specificity as possible