### PR TITLE
SFR-802 Update Hathi Identifier source

### DIFF
--- a/lib/dataModel.py
+++ b/lib/dataModel.py
@@ -188,9 +188,9 @@ class Agent(DataObject):
 
 
 class Identifier(DataObject):
-    def __init__(self, type=None, identifier=None, weight=None):
+    def __init__(self, source=None, identifier=None, weight=None):
         super()
-        self.type = type
+        self.type = source
         self.identifier = identifier
         self.weight = weight
 

--- a/lib/parsers/parse856Holding.py
+++ b/lib/parsers/parse856Holding.py
@@ -24,7 +24,7 @@ class HoldingParser:
 
     HATHI_OCLC_REGEX = r'([a-z]+\/[a-z0-9]+)\.html$'
 
-    HATHI_ID_REGEX = r'id=([a-z\.0-9]+)'
+    HATHI_ID_REGEX = r'id=([a-z\.\/\$0-9]+)'
 
     HATHI_DOWNLOAD_URL = 'babel.hathitrust.org/cgi/imgsrv/download/pdf?id={}'
     HATHI_METADATA_URL = 'http://catalog.hathitrust.org/api/volumes/full/{}.json' 
@@ -87,7 +87,7 @@ class HoldingParser:
                             local=False, download=False, images=False, ebook=True
                         )
                     ],
-                    'identifiers': [Identifier(identifier=self.identifier)]
+                    'identifiers': [Identifier(identifier=self.identifier, source='hathi')]
                 })
                 return True
     
@@ -201,7 +201,7 @@ class HoldingParser:
                     local=False, download=True, images=True, ebook=False
                 )
             ],
-            'identifiers': [Identifier(identifier=hathiID)]
+            'identifiers': [Identifier(identifier=hathiID, source='hathi')]
         }
 
     @staticmethod


### PR DESCRIPTION
These new identifiers with the items have been added without their `type`, which does not introduce a bug, but potentially makes it possible to create duplicate records as identifiers are the primary way we do instance/item matching and checking. This simply adds the type "hathi" to these identifiers